### PR TITLE
Add contact notification email on form submission

### DIFF
--- a/lib/actions/contantForm.ts
+++ b/lib/actions/contantForm.ts
@@ -5,6 +5,7 @@ import { ActionData } from "@/lib/formTypes";
 import { connectDB } from "../db/db";
 import contactModel from "../db/models/contactModel";
 import { contactSchema } from "../validation/schemas/contactSchema";
+import { sendContactNotification } from "../email/sendContactNotification";
 
 export const createContact = async (
   prevState: ActionData,
@@ -27,6 +28,12 @@ export const createContact = async (
     subject: result.data.subject,
     message: result.data.message,
   });
+
+  try {
+    await sendContactNotification(result.data);
+  } catch (error) {
+    console.error("Failed to send contact notification email", error);
+  }
 
   return {
     message: "SUCCESS",

--- a/lib/email/sendContactNotification.ts
+++ b/lib/email/sendContactNotification.ts
@@ -1,0 +1,51 @@
+type ContactPayload = {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+};
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const CONTACT_NOTIFY_EMAIL = process.env.CONTACT_NOTIFY_EMAIL;
+const CONTACT_FROM_EMAIL =
+  process.env.CONTACT_FROM_EMAIL || "Portfolio Contact <onboarding@resend.dev>";
+
+export const sendContactNotification = async (
+  payload: ContactPayload
+): Promise<void> => {
+  if (!RESEND_API_KEY || !CONTACT_NOTIFY_EMAIL) {
+    console.warn(
+      "Contact notification email skipped: RESEND_API_KEY or CONTACT_NOTIFY_EMAIL is missing."
+    );
+    return;
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: CONTACT_FROM_EMAIL,
+      to: [CONTACT_NOTIFY_EMAIL],
+      reply_to: payload.email,
+      subject: `New contact: ${payload.subject}`,
+      text: [
+        `Name: ${payload.name}`,
+        `Email: ${payload.email}`,
+        `Subject: ${payload.subject}`,
+        "",
+        payload.message,
+      ].join("\n"),
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Resend returned ${response.status}: ${response.statusText}. ${errorText}`
+    );
+  }
+};
+


### PR DESCRIPTION
Introduces sendContactNotification to send an email when a new contact form is submitted. Integrates the notification into createContact and handles errors gracefully if email sending fails.

## Summary by Sourcery

Send a notification email when a new contact form submission is created, without impacting the success of the form submission if email delivery fails.

New Features:
- Introduce sendContactNotification to send an email via Resend when a new contact form entry is created.

Enhancements:
- Wire contact creation to trigger a notification email and add graceful handling when email configuration is missing or the provider returns an error.